### PR TITLE
Move MCs to Team page

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -137,45 +137,6 @@
   social:
     - {name: "twitter", link: "https://twitter.com/dokun24"}
 -
-  id: "15"
-  name: "Marcy"
-  surname: "Regalado"
-  title: "UX Design Lead"
-  company: "Fidelity Investments"
-  bio: |
-   Marcy is a UX Design Lead at Fidelity Investments, where she currently is leading design and implementation of various innovative features for Fidelity mobile apps, wearables, website, and emerging platforms such as smart home devices. In her spare time, Marcy is a UX consultant working on the design and development of mobile apps and websites, mentorship for women in tech, sound designer and curator as a DJ, technology conference MCee, and an active Tufts alum.
-  thumbnailUrl: MarcyRegalado.jpg
-  rockstar: false
-  mc: true
-  social:
-    - {name: "twitter", link: "https://twitter.com/marcyregalado"}
--
-  id: "9"
-  name: "Andyy"
-  surname: "Hope"
-  title: "Software Engineer"
-  company: "Facebook"
-  bio: |
-   Andyy is a Software Engineer at Facebook and is also the founder of [Wu-Tang Clang](http://wutangclang.org/) which is a learn-to-code fundraiser, keeps a technical blog of Swift on [Medium](http://medium.com/@AndyyHope). Previously he was the organiser of [Playgrounds Conference](http://playgroundscon.com/).
-  thumbnailUrl: AndyyHope.jpg
-  rockstar: false
-  mc: true
-  social:
-    - {name: "twitter", link: "https://twitter.com/AndyyHope"}
--
-  id: "10"
-  name: "Garric"
-  surname: "Nahapetian"
-  title: "iOS Engineer"
-  company: "Tinder"
-  bio: |
-   Garric is an iOS Engineer at Tinder as well as the host of The SwiftCoders Podcast and the founder of the Learn Swift {CITY} group of meet ups.
-  thumbnailUrl: GarricNahapetian.jpg
-  rockstar: false
-  mc: true
-  social:
-    - {name: "twitter", link: "https://twitter.com/garricn"}
--
   id: "11"
   name: "Ish"
   surname: "Shabazz"
@@ -340,17 +301,6 @@
   social:
     - {name: "twitter", link: "https://twitter.com/WittedHaddock"}
     - {name: "linkedin", link: "https://www.linkedin.com/in/wittedhaddock/"}
--
-  id: "27"
-  name: "Alexandrea"
-  surname: "Mellen"
-  bio: |
-   Alexandrea Mellen is a technical content marketer at callstats.io. She has developed multiple iOS applications for her company, Terrapin Computing, as well as several freelance projects.
-  thumbnailUrl: AlexandreaMellen.jpg
-  rockstar: false
-  mc: true
-  social:
-    - {name: "twitter", link: "https://twitter.com/alexandreamel"}
 -
   id: "28"
   name: "Brad"

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -4,7 +4,7 @@
   surname: "Dias"
   title: "Community lead"
   thumbnailUrl: MattDias.jpg
-  team: true
+  type: team
   social:
     - {name: "twitter", link: "https://twitter.com/mdiasdev"}
     - {name: "github", link: "https://github.com/mdiasdev"}
@@ -14,7 +14,7 @@
   surname: "Eisenberg"
   title: "Tech lead"
   thumbnailUrl: ZevEisenberg.jpg
-  team: true
+  type: team
   social:
     - {name: "twitter", link: "https://twitter.com/ZevEisenberg"}
     - {name: "github", link: "https://github.com/ZevEisenberg"}
@@ -25,7 +25,7 @@
   surname: "Monahan"
   title: "Speakers liaison"
   thumbnailUrl: LucyMonahan.jpg
-  team: true
+  type: team
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/lucy-monahan-0838101/"}
     - {name: "twitter", link: "https://twitter.com/sofetching"}
@@ -35,7 +35,7 @@
   surname: "Natili"
   title: "Idea maker, team lead"
   thumbnailUrl: GiorgioNatili.jpg
-  team: true
+  type: team
   social:
     - {name: "twitter", link: "https://twitter.com/giorgionatili"}
     - {name: "linkedin", link: "https://www.linkedin.com/in/giorgionatili"}
@@ -45,7 +45,7 @@
   surname: "O’Leary"
   title: "Content lead"
   thumbnailUrl: JeffOLeary.jpg
-  team: true
+  type: team
   social:
     - {name: "github",link: "https://github.com/joleary1987"}
 -
@@ -54,7 +54,7 @@
   surname: "Olszewski"
   title: "Development lead"
   thumbnailUrl: SeanOlszewski.jpg
-  team: true
+  type: team
   social:
     - {name: "github", link: "https://github.com/SeanROlszewski/"}
 
@@ -64,7 +64,7 @@
   surname: "Pineda"
   title: "Volunteers coordinator"
   thumbnailUrl: AndresPineda.jpg
-  team: true
+  type: team
   social:
     - {name: "twitter", link: "https://twitter.com/ajpinedam"}
     - {name: "github", link: "https://github.com/ajpinedam"}
@@ -75,7 +75,7 @@
   surname: "Menicucci"
   title: "Event Manager"
   thumbnailUrl: BarbaraMenicucci.jpg
-  team: true
+  type: team
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/barbara-menicucci-57ab939a/"}
 -
@@ -84,7 +84,7 @@
   surname: "Alberto"
   title: "Mobile developer"
   thumbnailUrl: LuisAlberto.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "github", link: "https://github.com/luis-alberto-pena-nunez"}
     - {name: "linkedin", link: "https://www.linkedin.com/in/luis-alberto-pe%C3%B1a-nu%C3%B1ez-aa70a5103"}
@@ -94,7 +94,7 @@
   surname: "Bruce"
   title: "Open space coordinator"
   thumbnailUrl: PaulBruce.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "twitter", link: "https://twitter.com/paulsbruce"}
     - {name: "linkedin", link: "https://www.linkedin.com/in/paulsbruce/"}
@@ -104,7 +104,7 @@
   surname: "Van"
   title: "iOS Developer"
   thumbnailUrl: BarbaraVanaki.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/284779163"}
 -
@@ -113,7 +113,7 @@
   surname: "Ryczek"
   title: "Mobile Developer"
   thumbnailUrl: BryanRyczek.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/bryanryczek/"}
     - {name: "twitter", link: "https://twitter.com/bryanryczek"}
@@ -124,7 +124,7 @@
   surname: "Ramirez"
   title: "Operations Manager"
   thumbnailUrl: YohannaRamirez.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/yohanna-ramirez-bbba9791/"}
 
@@ -134,7 +134,7 @@
   surname: "Taveras"
   title: "Mobile Developer"
   thumbnailUrl: JoseTaveras.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/jose-gregorio-taveras-taveras-16738952/"}
     - {name: "twitter", link: "https://twitter.com/JGTaveras"}
@@ -145,7 +145,7 @@
   surname: "Shenoy"
   title: "iOS Developer"
   thumbnailUrl: MythriShenoy.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/my3vshenoy/"}
 
@@ -155,8 +155,54 @@
   surname: "Buonocore"
   title: "Software Engineer"
   thumbnailUrl: ChrisBuonocore.jpg
-  volunteer: true
+  type: volunteer
   social:
     - {name: "linkedin", link: "https://www.linkedin.com/in/chrisbuonocore/"}
 
-
+-
+  id: "16"
+  name: "Alexandrea"
+  surname: "Mellen"
+  bio: |
+   Alexandrea Mellen is a technical content marketer at callstats.io. She has developed multiple iOS applications for her company, Terrapin Computing, as well as several freelance projects.
+  thumbnailUrl: AlexandreaMellen.jpg
+  type: mc
+  social:
+    - {name: "twitter", link: "https://twitter.com/alexandreamel"}
+-
+  id: "17"
+  name: "Marcy"
+  surname: "Regalado"
+  title: "UX Design Lead"
+  company: "Fidelity Investments"
+  bio: |
+   Marcy is a UX Design Lead at Fidelity Investments, where she currently is leading design and implementation of various innovative features for Fidelity mobile apps, wearables, website, and emerging platforms such as smart home devices. In her spare time, Marcy is a UX consultant working on the design and development of mobile apps and websites, mentorship for women in tech, sound designer and curator as a DJ, technology conference MCee, and an active Tufts alum.
+  thumbnailUrl: MarcyRegalado.jpg
+  type: mc
+  social:
+    - {name: "twitter", link: "https://twitter.com/marcyregalado"}
+-
+  id: "9"
+  name: "Andyy"
+  surname: "Hope"
+  title: "Software Engineer"
+  company: "Facebook"
+  bio: |
+   Andyy is a Software Engineer at Facebook and is also the founder of [Wu-Tang Clang](http://wutangclang.org/) which is a learn-to-code fundraiser, keeps a technical blog of Swift on [Medium](http://medium.com/@AndyyHope). Previously he was the organiser of [Playgrounds Conference](http://playgroundscon.com/).
+  thumbnailUrl: AndyyHope.jpg
+  type: mc
+  social:
+    - {name: "twitter", link: "https://twitter.com/AndyyHope"}
+-
+  id: "10"
+  name: "Garric"
+  surname: "Nahapetian"
+  title: "iOS Engineer"
+  company: "Tinder"
+  bio: |
+   Garric is an iOS Engineer at Tinder as well as the host of The SwiftCoders Podcast and the founder of the Learn Swift {CITY} group of meet ups.
+  thumbnailUrl: GarricNahapetian.jpg
+  rockstar: false
+  type: mc
+  social:
+    - {name: "twitter", link: "https://twitter.com/garricn"}

--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -6,7 +6,7 @@
     <div class="content-wrapper">
         <div class="col-lg-10 col-lg-offset-1">
             <div class="row text-left appear-animation-trigger">
-                {% for speaker in all_speakers %}{% if speaker.mc != true %}
+                {% for speaker in all_speakers %}
                 <div class="effect-wrapper appear-animation col-md-4 col-sm-6 col-xs-12">
                     <div class="lily-effect ribbon-activator">
                         <div class="lily-head" data-toggle="modal" data-target="#speakerDetail-{{ speaker.id }}">
@@ -51,40 +51,8 @@
                         </div>
                     </div>
                 </div>
-                {% endif %}{% endfor %}
+                {% endfor %}
             </div>
-            <h2>MCs</h2>
-            <div class="col-lg-10 col-lg-offset-1">
-                <div class="row text-left appear-animation-trigger">
-                    {% for speaker in all_speakers %}{% if speaker.mc == true %}
-                    <div class="effect-wrapper appear-animation col-md-4 col-sm-6 col-xs-12">
-                        <div class="lily-effect ribbon-activator">
-                            <div class="lily-head" data-toggle="modal" data-target="#speakerDetail-{{ speaker.id }}">
-                                <figure class="waves-effect waves-block waves-light" style="background-image: url({{ site.baseurl | append: '/img/people/' | append: speaker.thumbnailUrl }}); background-position: center 30%;">
-                                    <div class="overlay solid-overlay"></div>
-                                    {% if speaker.ribbon != null %}
-                                    <ul class="ribbon-wrapper">
-                                        {% for ribbon in speaker.ribbon %}
-                                        <li class="{{ ribbon["abbr"] | downcase }}">
-                                            <p class="ribbon abbr">{{ ribbon["abbr"] }}</p>
-                                            <p class="ribbon full-title">{{ ribbon["title"] }}</p>
-                                        </li>
-                                        {% endfor %}
-                                    </ul>
-                                    {% endif %}
-                                    {% if site.showSessions %}
-                                    <figcaption>
-                                        <h2 class="name">{{ speaker.name }} <span>{{ speaker.surname }}</span></h2>
-                                        <p class="position">{{ speaker.company }}</p>
-                                    </figcaption>
-                                    {% endif %}
-                                </figure>
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}{% endfor %}
-                </div>
-        </div>
     </div>
 </section>
 <!-- End Speakers List -->

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,8 @@
         </div>
         <div class="col-lg-10 col-lg-offset-1 text-center">
             <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">Organizers</h4>
-            {% for teamMember in sortedTeam %} {% if teamMember.team != null %}
+            {% assign organizers = sortedTeam | where: 'type', 'team' %}
+            {% for teamMember in organizers %}
             <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">
                 <div class="zoe-effect" data-toggle="modal" data-target="#speakerDetail-{{ teamMember.id }}">
                     <figure class="waves-effect waves-block waves-light" style="background-image: url({{ site.baseurl | append: '/img/people/' | append: teamMember.thumbnailUrl }})">
@@ -32,13 +33,13 @@
                     </figure>
                 </div>
             </div>
-            {% endif %} {% endfor %}
+            {% endfor %}
         </div>
         <div class="col-lg-10 col-lg-offset-1 text-center">
-            {% assign volunteers = sortedTeam | where: 'volunteer',true %}
-            {% if volunteers | size > 0 %}
-            <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">Volunteers</h4>
-            {% for teamMember in volunteers %} {% if teamMember.volunteer %}
+            {% assign mcs = sortedTeam | where: 'type', 'mc' %}
+            {% if mcs | size > 0 %}
+            <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">MCs</h4>
+            {% for teamMember in mcs %}
             <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">
                 <div class="zoe-effect" data-toggle="modal" data-target="#speakerDetail-{{ teamMember.id }}">
                     <figure class="waves-effect waves-block waves-light" style="background-image: url({{ site.baseurl | append: '/img/people/' | append: teamMember.thumbnailUrl }})">
@@ -60,9 +61,39 @@
                     </figure>
                 </div>
             </div>
-            {% endif %} {% endfor %} {% endif %}
+            {% endfor %} {% endif %}
+        </div>
+        <div class="col-lg-10 col-lg-offset-1 text-center">
+            {% assign volunteers = sortedTeam | where: 'type', 'volunteer' %}
+            {% if volunteers | size > 0 %}
+            <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">Volunteers</h4>
+            {% for teamMember in volunteers %}
+            <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">
+                <div class="zoe-effect" data-toggle="modal" data-target="#speakerDetail-{{ teamMember.id }}">
+                    <figure class="waves-effect waves-block waves-light" style="background-image: url({{ site.baseurl | append: '/img/people/' | append: teamMember.thumbnailUrl }})">
+                        <div class="overlay solid-overlay"></div>
+                        <figcaption>
+                            <div class="col-md-8 col-xs-8 text-left">
+                                <h2 class="name">{{ teamMember.name }} <span>{{ teamMember.surname }}</span></h2>
+                                <div class="clearfix"></div>
+                                <span class="position">{{ teamMember.title }}</span>
+                            </div>
+                            {% for social in teamMember.social %}
+                            <a href="{{ social["link"] }}" target="_blank">
+                                <svg class="icon icon-{{ social["name"] }}" viewBox="0 0 30 32">
+                                    <use xlink:href="{{ site.baseurl }}/img/sprites/sprites.svg#icon-{{ social["name"] }}"></use>
+                                </svg>
+                            </a>
+                            {% endfor %}
+                        </figcaption>
+                    </figure>
+                </div>
+            </div>
+            {% endfor %} {% endif %}
+        </div>
+        <div class="col-lg-10 col-lg-offset-1 text-center">
             <p>
-              <a href="https://www.freepik.com/free-photos-vectors/business" style="color: #aaa;">Business image created by Jcomp - Freepik.com</a>
+                <a href="https://www.freepik.com/free-photos-vectors/business" style="color: #aaa;">Business image created by Jcomp - Freepik.com</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
@SeanROlszewski @cbonoz moving the MCs to the Team page, which we were thinking made more sense than keeping them on the Speakers page, but they get their own section on the Team page. JSON should be up to date as well. Going to merge this; just tagging you so you know it happened.